### PR TITLE
fix bug: Class Apiship\Entity\Response\ListsPointTypesResponse locate…

### DIFF
--- a/src/Api/Lists.php
+++ b/src/Api/Lists.php
@@ -3,7 +3,7 @@
 namespace Apiship\Api;
 
 use Apiship\Entity\Response\ListsPointsResponse;
-use Apiship\Entity\Response\ListsPointTypesResponse;
+use Apiship\Entity\Response\Part\ListsPointTypesResponse;
 use Apiship\Entity\Response\ListsProvidersResponse;
 use Apiship\Entity\Response\Part\Lists\Point;
 use Apiship\Entity\Response\Part\Lists\PointType;

--- a/src/Entity/Response/Part/ListsPointTypesResponse.php
+++ b/src/Entity/Response/Part/ListsPointTypesResponse.php
@@ -4,7 +4,7 @@
  * @copyright Serge Rodovnichenko, 2020
  */
 
-namespace Apiship\Entity\Response;
+namespace Apiship\Entity\Response\Part;
 
 use Apiship\Entity\AbstractResponse;
 use Apiship\Entity\Response\Part\Lists\PointType;


### PR DESCRIPTION
…d in ./vendor/apiship/apiship-sdk-php/src/Entity/Response/Part/ListsPointTypesResponse.php does not comply with psr-4 autoloading standard