### PR TITLE
Move guzzle to suggests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "require": {
     "php": ">=5.5.0"
   },
-  "suggest": {
-     "guzzlehttp/guzzle": "Needed if you want to use guzzle adapter",
+  "suggests": {
+     "guzzlehttp/guzzle": "Needed if you want to use GuzzleAdapter"
   }
 }


### PR DESCRIPTION
Так как принципиально пакет можно использовать без guzzle то имеет смысл убрать его из require и перенести в suggests

Таким образом те, кто не планирует использовать GuzzleAdapter могут не тащить себе эту зависимость.
Также стоит подумать над поддержкой guzzle 7.0. Не знаю поддерживает ли сейчас её пакет.

Сейчас из-за этого невозможно установить пакет например на последней версии Laravel 