### PR TITLE
Добавление полей "Типы забора" и "Типы доставки" для тарифов

### DIFF
--- a/src/Api/Calculator.php
+++ b/src/Api/Calculator.php
@@ -37,7 +37,9 @@ class Calculator extends AbstractApi
                                              ->setFrom(isset($itemTariff->from) ? $itemTariff->from : null)
                                              ->setDeliveryCost(isset($itemTariff->deliveryCost) ? $itemTariff->deliveryCost : null)
                                              ->setDaysMin(isset($itemTariff->daysMin) ? $itemTariff->daysMin : null)
-                                             ->setDaysMax(isset($itemTariff->daysMax) ? $itemTariff->daysMax : null);
+                                             ->setDaysMax(isset($itemTariff->daysMax) ? $itemTariff->daysMax : null)
+                                             ->setPickupTypes(isset($itemTariff->pickupTypes) ? $itemTariff->pickupTypes : [])
+                                             ->setDeliveryTypes(isset($itemTariff->deliveryTypes) ? $itemTariff->deliveryTypes : []);
 
                         $calculatorItem->addTariff($calculatorItemTariff);
                     }
@@ -59,7 +61,9 @@ class Calculator extends AbstractApi
                                              ->setDeliveryCost(isset($itemTariff->deliveryCost) ? $itemTariff->deliveryCost : null)
                                              ->setDaysMin(isset($itemTariff->daysMin) ? $itemTariff->daysMin : null)
                                              ->setDaysMax(isset($itemTariff->daysMax) ? $itemTariff->daysMax : null)
-                                             ->setPointIds(isset($itemTariff->pointIds) ? $itemTariff->pointIds : []);
+                                             ->setPointIds(isset($itemTariff->pointIds) ? $itemTariff->pointIds : [])
+                                             ->setPickupTypes(isset($itemTariff->pickupTypes) ? $itemTariff->pickupTypes : [])
+                                             ->setDeliveryTypes(isset($itemTariff->deliveryTypes) ? $itemTariff->deliveryTypes : []);
 
                         $calculatorItem->addTariff($calculatorItemTariff);
                     }

--- a/src/Entity/Response/Part/Calculator/Tariff.php
+++ b/src/Entity/Response/Part/Calculator/Tariff.php
@@ -6,191 +6,239 @@ use Apiship\Entity\AbstractResponsePart;
 
 class Tariff extends AbstractResponsePart
 {
-    /**
-     * @var int ID тарифа
-     */
-    protected $tariffId;
-    /**
-     * @var string Наименование тарифа
-     */
-    protected $tariffName;
-    /**
-     * @var string Откуда производится доставка
-     * (door - от двери клиента, point - от терминала службы доставки, pointOrDoor - любым из предыдущих способом
-     */
-    protected $from;
-    /**
-     * @var float Стоимость доставки
-     */
-    protected $deliveryCost;
-    /**
-     * @var int Минимальное количество дней на доставку
-     */
-    protected $daysMin;
-    /**
-     * @var int Максимальное количество дней на доставку
-     */
-    protected $daysMax;
+	/**
+	 * @var int ID тарифа
+	 */
+	protected $tariffId;
+	/**
+	 * @var string Наименование тарифа
+	 */
+	protected $tariffName;
+	/**
+	 * @var string Откуда производится доставка
+	 * (door - от двери клиента, point - от терминала службы доставки, pointOrDoor - любым из предыдущих способом
+	 */
+	protected $from;
+	/**
+	 * @var float Стоимость доставки
+	 */
+	protected $deliveryCost;
+	/**
+	 * @var int Минимальное количество дней на доставку
+	 */
+	protected $daysMin;
+	/**
+	 * @var int Максимальное количество дней на доставку
+	 */
+	protected $daysMax;
 
-    /**
-     * @var array Список ID ПВЗ
-     */
-    protected $pointIds = [];
+	/**
+	 * @var array Список ID ПВЗ
+	 */
+	protected $pointIds = [];
 
-    /**
-     * @var string|null Кастомное описание тарифа
-     */
-    protected $tariffDescription = null;
+	/**
+	 * @var string|null Кастомное описание тарифа
+	 */
+	protected $tariffDescription = null;
 
-    /**
-     * @return string|null
-     */
-    public function getTariffDescription()
-    {
-        return $this->tariffDescription;
-    }
+	/**
+	 * @var array Типы забора
+	 */
+	protected $pickupTypes = [];
 
-    /**
-     * @param string|null $tariffDescription
-     * @return Tariff
-     */
-    public function setTariffDescription($tariffDescription)
-    {
-        $this->tariffDescription = $tariffDescription;
-        return $this;
-    }
+	/**
+	 * @var array Типы доставки
+	 */
+	protected $deliveryTypes = [];
 
-    /**
-     * @return int
-     */
-    public function getTariffId()
-    {
-        return $this->tariffId;
-    }
+	/**
+	 * @return string|null
+	 */
+	public function getTariffDescription()
+	{
+		return $this->tariffDescription;
+	}
 
-    /**
-     * @param int $tariffId
-     *
-     * @return Tariff
-     */
-    public function setTariffId($tariffId)
-    {
-        $this->tariffId = $tariffId;
-        return $this;
-    }
+	/**
+	 * @param string|null $tariffDescription
+	 * @return Tariff
+	 */
+	public function setTariffDescription($tariffDescription)
+	{
+		$this->tariffDescription = $tariffDescription;
+		return $this;
+	}
 
-    /**
-     * @return string
-     */
-    public function getTariffName()
-    {
-        return $this->tariffName;
-    }
+	/**
+	 * @return int
+	 */
+	public function getTariffId()
+	{
+		return $this->tariffId;
+	}
 
-    /**
-     * @param string $tariffName
-     *
-     * @return Tariff
-     */
-    public function setTariffName($tariffName)
-    {
-        $this->tariffName = $tariffName;
-        return $this;
-    }
+	/**
+	 * @param int $tariffId
+	 *
+	 * @return Tariff
+	 */
+	public function setTariffId($tariffId)
+	{
+		$this->tariffId = $tariffId;
+		return $this;
+	}
 
-    /**
-     * @return string
-     */
-    public function getFrom()
-    {
-        return $this->from;
-    }
+	/**
+	 * @return string
+	 */
+	public function getTariffName()
+	{
+		return $this->tariffName;
+	}
 
-    /**
-     * @param string $from
-     *
-     * @return Tariff
-     */
-    public function setFrom($from)
-    {
-        $this->from = $from;
-        return $this;
-    }
+	/**
+	 * @param string $tariffName
+	 *
+	 * @return Tariff
+	 */
+	public function setTariffName($tariffName)
+	{
+		$this->tariffName = $tariffName;
+		return $this;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getFrom()
+	{
+		return $this->from;
+	}
+
+	/**
+	 * @param string $from
+	 *
+	 * @return Tariff
+	 */
+	public function setFrom($from)
+	{
+		$this->from = $from;
+		return $this;
+	}
 
 
-    /**
-     * @return array
-     */
-    public function getPointIds()
-    {
-        return $this->pointIds;
-    }
+	/**
+	 * @return array
+	 */
+	public function getPointIds()
+	{
+		return $this->pointIds;
+	}
 
-    /**
-     * @param array $pointIds
-     *
-     * @return Tariff
-     */
-    public function setPointIds(array $pointIds)
-    {
-        $this->pointIds = $pointIds;
-        return $this;
-    }
+	/**
+	 * @param array $pointIds
+	 *
+	 * @return Tariff
+	 */
+	public function setPointIds(array $pointIds)
+	{
+		$this->pointIds = $pointIds;
+		return $this;
+	}
 
-    /**
-     * @return float
-     */
-    public function getDeliveryCost()
-    {
-        return $this->deliveryCost;
-    }
+	/**
+	 * @return float
+	 */
+	public function getDeliveryCost()
+	{
+		return $this->deliveryCost;
+	}
 
-    /**
-     * @param float $deliveryCost
-     *
-     * @return Tariff
-     */
-    public function setDeliveryCost($deliveryCost)
-    {
-        $this->deliveryCost = $deliveryCost;
-        return $this;
-    }
+	/**
+	 * @param float $deliveryCost
+	 *
+	 * @return Tariff
+	 */
+	public function setDeliveryCost($deliveryCost)
+	{
+		$this->deliveryCost = $deliveryCost;
+		return $this;
+	}
 
-    /**
-     * @return int
-     */
-    public function getDaysMin()
-    {
-        return $this->daysMin;
-    }
+	/**
+	 * @return int
+	 */
+	public function getDaysMin()
+	{
+		return $this->daysMin;
+	}
 
-    /**
-     * @param int $daysMin
-     *
-     * @return Tariff
-     */
-    public function setDaysMin($daysMin)
-    {
-        $this->daysMin = $daysMin;
-        return $this;
-    }
+	/**
+	 * @param int $daysMin
+	 *
+	 * @return Tariff
+	 */
+	public function setDaysMin($daysMin)
+	{
+		$this->daysMin = $daysMin;
+		return $this;
+	}
 
-    /**
-     * @return int
-     */
-    public function getDaysMax()
-    {
-        return $this->daysMax;
-    }
+	/**
+	 * @return int
+	 */
+	public function getDaysMax()
+	{
+		return $this->daysMax;
+	}
 
-    /**
-     * @param int $daysMax
-     *
-     * @return Tariff
-     */
-    public function setDaysMax($daysMax)
-    {
-        $this->daysMax = $daysMax;
-        return $this;
-    }
+	/**
+	 * @param int $daysMax
+	 *
+	 * @return Tariff
+	 */
+	public function setDaysMax($daysMax)
+	{
+		$this->daysMax = $daysMax;
+		return $this;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getPickupTypes()
+	{
+		return $this->pickupTypes;
+	}
+
+	/**
+	 * @param array $pickupTypes
+	 *
+	 * @return Tariff
+	 */
+	public function setPickupTypes(array $pickupTypes)
+	{
+		$this->pickupTypes = $pickupTypes;
+		return $this;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getDeliveryTypes()
+	{
+		return $this->deliveryTypes;
+	}
+
+	/**
+	 * @param array $deliveryTypes
+	 *
+	 * @return Tariff
+	 */
+	public function setDeliveryTypes(array $deliveryTypes)
+	{
+		$this->deliveryTypes = $deliveryTypes;
+		return $this;
+	}
 }


### PR DESCRIPTION
Так как для метода "POST/calculator" в параметрах ответа по разделам "deliveryToDoor" и "deliveryToPoint" поле "from" уже признано устаревшим и даже удалено из документации, поддержка сервиса Apiship не рекомендует его использовать. Вместо этого предлагается использовать поле "Тип забора груза" в параметре pickupTypes. Дополнительно также предлагается получать данные и для поля "Типы доставки" в параметре deliveryTypes.