### PR TITLE
Добавление полей "Типы забора" и "Типы доставки" для тарифа

### DIFF
--- a/src/Api/Calculator.php
+++ b/src/Api/Calculator.php
@@ -37,7 +37,9 @@ class Calculator extends AbstractApi
                                              ->setFrom(isset($itemTariff->from) ? $itemTariff->from : null)
                                              ->setDeliveryCost(isset($itemTariff->deliveryCost) ? $itemTariff->deliveryCost : null)
                                              ->setDaysMin(isset($itemTariff->daysMin) ? $itemTariff->daysMin : null)
-                                             ->setDaysMax(isset($itemTariff->daysMax) ? $itemTariff->daysMax : null);
+                                             ->setDaysMax(isset($itemTariff->daysMax) ? $itemTariff->daysMax : null)
+                                             ->setPickupTypes(isset($itemTariff->pickupTypes) ? $itemTariff->pickupTypes : [])
+                                             ->setDeliveryTypes(isset($itemTariff->deliveryTypes) ? $itemTariff->deliveryTypes : []);
 
                         $calculatorItem->addTariff($calculatorItemTariff);
                     }
@@ -59,7 +61,9 @@ class Calculator extends AbstractApi
                                              ->setDeliveryCost(isset($itemTariff->deliveryCost) ? $itemTariff->deliveryCost : null)
                                              ->setDaysMin(isset($itemTariff->daysMin) ? $itemTariff->daysMin : null)
                                              ->setDaysMax(isset($itemTariff->daysMax) ? $itemTariff->daysMax : null)
-                                             ->setPointIds(isset($itemTariff->pointIds) ? $itemTariff->pointIds : []);
+                                             ->setPointIds(isset($itemTariff->pointIds) ? $itemTariff->pointIds : [])
+                                             ->setPickupTypes(isset($itemTariff->pickupTypes) ? $itemTariff->pickupTypes : [])
+                                             ->setDeliveryTypes(isset($itemTariff->deliveryTypes) ? $itemTariff->deliveryTypes : []);
 
                         $calculatorItem->addTariff($calculatorItemTariff);
                     }

--- a/src/Entity/Response/Part/Calculator/Tariff.php
+++ b/src/Entity/Response/Part/Calculator/Tariff.php
@@ -43,6 +43,16 @@ class Tariff extends AbstractResponsePart
     protected $tariffDescription = null;
 
     /**
+     * @var array Типы забора
+     */
+    protected $pickupTypes = [];
+
+    /**
+     * @var array Типы доставки
+     */
+    protected $deliveryTypes = [];
+
+    /**
      * @return string|null
      */
     public function getTariffDescription()
@@ -191,6 +201,44 @@ class Tariff extends AbstractResponsePart
     public function setDaysMax($daysMax)
     {
         $this->daysMax = $daysMax;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPickupTypes()
+    {
+        return $this->pickupTypes;
+    }
+
+    /**
+     * @param array $pickupTypes
+     *
+     * @return Tariff
+     */
+    public function setPickupTypes(array $pickupTypes)
+    {
+        $this->pickupTypes = $pickupTypes;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getDeliveryTypes()
+    {
+        return $this->deliveryTypes;
+    }
+
+    /**
+     * @param array $deliveryTypes
+     *
+     * @return Tariff
+     */
+    public function setDeliveryTypes(array $deliveryTypes)
+    {
+        $this->deliveryTypes = $deliveryTypes;
         return $this;
     }
 }


### PR DESCRIPTION
Так как для метода "POST/calculator" в параметрах ответа по разделам "deliveryToDoor" и "deliveryToPoint" поле "from" уже признано устаревшим и даже удалено из документации, поддержка сервиса Apiship не рекомендует его использовать. Вместо этого предлагается использовать поле "Тип забора груза" в параметре pickupTypes. Дополнительно также предлагается получать данные и для поля "Типы доставки" в параметре deliveryTypes.