### PR TITLE
Возможность указать какие поля отдавать для /lists/points

### DIFF
--- a/src/Api/Lists.php
+++ b/src/Api/Lists.php
@@ -73,11 +73,11 @@ class Lists extends AbstractApi
      *
      * @param int $offset
      * @param string $filter Возможна фильтрация по полям key, name
-     * @param string $fields Указать, какие поля необходимо вернуть. Если пусто - вернуть всё.
      * @param bool $stateCheckOff Если stateCheckOff=1 отдаются также ПВЗ у которых указан не точный адрес расположения
+     * @param string $fields Указать, какие поля необходимо вернуть. Если пусто - вернуть всё.
      * @return ListsPointsResponse
      */
-    public function getPoints($limit = 20, $offset = 0, $filter = '', $fields = '', $stateCheckOff = false)
+    public function getPoints($limit = 20, $offset = 0, $filter = '', $stateCheckOff = false, $fields = '')
     {
         if (!is_int($limit) || $limit < 0) {
             $limit = 20;

--- a/src/Api/Lists.php
+++ b/src/Api/Lists.php
@@ -73,10 +73,11 @@ class Lists extends AbstractApi
      *
      * @param int $offset
      * @param string $filter Возможна фильтрация по полям key, name
+     * @param string $fields Указать, какие поля необходимо вернуть. Если пусто - вернуть всё.
      * @param bool $stateCheckOff Если stateCheckOff=1 отдаются также ПВЗ у которых указан не точный адрес расположения
      * @return ListsPointsResponse
      */
-    public function getPoints($limit = 20, $offset = 0, $filter = '', $stateCheckOff = false)
+    public function getPoints($limit = 20, $offset = 0, $filter = '', $fields = '', $stateCheckOff = false)
     {
         if (!is_int($limit) || $limit < 0) {
             $limit = 20;
@@ -93,6 +94,7 @@ class Lists extends AbstractApi
                 'limit'         => $limit,
                 'offset'        => $offset,
                 'filter'        => $filter,
+                'fields'        => $fields,
                 'stateCheckOff' => $stateCheckOff,
             ]
         );


### PR DESCRIPTION
Для уменьшения объёма передаваемых данных добавил возможность определять поля, которые будут возвращаться в ответе на [GET /lists/points](https://docs.apiship.ru/docs/api/lists-points/#%d0%bf%d0%b0%d1%80%d0%b0%d0%bc%d0%b5%d1%82%d1%80%d1%8b-%d0%b7%d0%b0%d0%bf%d1%80%d0%be%d1%81%d0%b0)
